### PR TITLE
Fix red box version and tsconfig update

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"express": "^4.13.3",
 		"react-transform-catch-errors": "^1.0.0",
 		"react-transform-hmr": "^1.0.0",
-		"redbox-react": "^1.2.6",
+		"redbox-react": "1.2.6",
 		"rimraf": "^2.4.3",
 		"ts-loader": "^0.7.2",
 		"typescript": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"express": "^4.13.3",
 		"react-transform-catch-errors": "^1.0.0",
 		"react-transform-hmr": "^1.0.0",
-		"redbox-react": "^1.0.1",
+		"redbox-react": "^1.2.6",
 		"rimraf": "^2.4.3",
 		"ts-loader": "^0.7.2",
 		"typescript": "^1.6.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "ES6",
-		"jsx": "react",
-		"noEmit": true
+		"jsx": "react"		
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
Fix for issue #10 we need to stick to a given version of redbox-react (see: [https://github.com/halt-hammerzeit/webpack-react-redux-isomorphic-render-example/issues/2](https://github.com/halt-hammerzeit/webpack-react-redux-isomorphic-render-example/issues/2)

Fix for issue #8 included as well (typescript config update to avoid erro when transpiling).
